### PR TITLE
Updated typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Inside `gatsby-config.js`, set up the theme:
 
 ```js
 module.exports = {
-  __experimentalThemes: ['gatsby-theme-simple-blog']
+  __experimentalThemes: ['gatsby-theme-simple-docs']
 };
 ```
 


### PR DESCRIPTION
there was a reference to `gatsby-theme-simple-blog` when it should have been `gatsby-theme-simple-docs`